### PR TITLE
Update reports.js

### DIFF
--- a/lib/helpers/reports.js
+++ b/lib/helpers/reports.js
@@ -219,6 +219,7 @@ const requestAndDownloadReport = api => async (ReportType, file, reportParams = 
     const reportRequestId = request.ReportRequestId;
     await sleep(20000); // some requests may be available quickly, check after 20 sec
     const reportCheck = await checkReportComplete(reportRequestId);
+    if (!reportCheck) return null;
     if (reportCheck.cancelled) {
         console.warn('******** report request cancelled by server', ReportType);
         throw new errors.RequestCancelled('Report cancelled by server');


### PR DESCRIPTION
`checkReportComplete()` returns null in case "_DONE_NO_DATA". If you wouldn't check for this case then reportCheck.cancelled will throw an error if this case occurs.